### PR TITLE
allow custom filename not only for download, but also for show function

### DIFF
--- a/src/Thujohn/Pdf/Pdf.php
+++ b/src/Thujohn/Pdf/Pdf.php
@@ -40,9 +40,9 @@ class Pdf {
 		return $this->dompdf->render();
 	}
 
-	public function show($options = array('compress' => 1, 'Attachment' => 0)){
+	public function show($filename = 'dompdf_out', $options = array('compress' => 1, 'Attachment' => 0)){
 		$this->render();
-		return $this->dompdf->stream('dompdf_out.pdf', $options);
+		return $this->dompdf->stream($filename.'.pdf', $options);
 	}
 
 	public function download($filename = 'dompdf_out', $options = array('compress' => 1, 'Attachment' => 1)){


### PR DESCRIPTION
Why not allow a custom filename for the show function? I know, basically it's just

```
PDF::load($view, 'A4', 'landscape')->download('filename', array('compress' => 1, 'Attachment' => 0));
```

vs

```
PDF::load($view, 'A4', 'landscape')->show('filename');
```

but I think for the sake of readability this should be added.
