### PR TITLE
Allow illuminati 4.x and 5.x for laravel develop branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.x"
+        "illuminate/support": "4.*|5.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
This change makes it possible to use this package if you run the latest laravel branch which will become Laravel 5 by the end of the month. 
