### PR TITLE
Removed a duplicated header "Content-Disposition"

### DIFF
--- a/src/Thujohn/Pdf/Pdf.php
+++ b/src/Thujohn/Pdf/Pdf.php
@@ -56,8 +56,7 @@ class Pdf {
 		$this->render();
 		$this->clear();
 		return new Response($this->dompdf->stream($filename.'.pdf', $options), 200, array(
-                    'Content-Type' => 'application/pdf',
-                    'Content-Disposition' =>  'attachment; filename="'.$filename.'"'
+                    'Content-Type' => 'application/pdf'                    
                 ));
 	}
 


### PR DESCRIPTION
The header "Content-Disposition" is set in Pdf.php and in dompdf/include/pdflib_adapter.cls.php so with modern browsers i get the error "ERR_RESPONSE_HEADERS_MULTIPLE_CONTENT_DISPOSITION" on download of generated pdf.

This patch should resolve.
